### PR TITLE
Fix parsing of "version needed to extract" field

### DIFF
--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -578,7 +578,8 @@ getFileHeader locals = do
      else do
        skip 4 -- skip past signature
        skip 2 -- version made by
-       versionNeededToExtract <- getWord16le
+       versionNeededToExtract <- getWord8
+       skip 1 -- upper byte indicates OS part of "version needed to extract"
        unless (versionNeededToExtract <= 20) $
          fail "This archive requires zip >= 2.0 to extract."
        skip 2 -- general purpose bit flag


### PR DESCRIPTION
This field consists of two bytes, upper one indicating host OS and lower one
indicating version of Zip (de)compressor. Tomake sure if one can unpack given
archive it's only lower byte which is needed to be checked, but library used
to check both.

Thank you for nice library!
