### PR TITLE
fix build failure against directory-1.2 (missing liftM)

### DIFF
--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -68,6 +68,9 @@ import Text.Printf
 import System.FilePath
 import System.Directory ( doesDirectoryExist, getDirectoryContents, createDirectoryIfMissing )
 import Control.Monad ( when, unless, zipWithM )
+#if MIN_VERSION_directory(1,2,0)
+import Control.Monad ( liftM )
+#endif
 import System.Directory ( getModificationTime )
 import System.IO ( stderr, hPutStrLn )
 import qualified Data.Digest.CRC32 as CRC32


### PR DESCRIPTION
[1 of 1] Compiling Codec.Archive.Zip ( Codec/Archive/Zip.hs, dist/build/Codec/Archive/Zip.o )

Codec/Archive/Zip.hs:207:19:
    Not in scope: `liftM'
    Perhaps you meant`liftA' (imported from Control.Applicative)

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
