### PR TITLE
set bit 11 in the file header (file names are UTF-8 encoded)

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+zip-archive 0.2.2
+  * Set bit 11 in the file header to insure other programs
+    recognize UTF-8 encoded file names
+
 zip-archive 0.2.1
 
   * Added OptLocation, to specify the path to which a file

--- a/src/Codec/Archive/Zip.hs
+++ b/src/Codec/Archive/Zip.hs
@@ -671,7 +671,7 @@ putFileHeader offset local = do
   putWord32le 0x02014b50
   putWord16le 0  -- version made by
   putWord16le 20 -- version needed to extract (>= 2.0)
-  putWord16le 2  -- general purpose bit flag (max compression)
+  putWord16le 0x802  -- general purpose bit flag (bit 1 = max compression, bit 11 = UTF-8)
   putWord16le $ case eCompressionMethod local of
                      NoCompression -> 0
                      Deflate       -> 8

--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -1,5 +1,5 @@
 Name:                zip-archive
-Version:             0.2.1
+Version:             0.2.2
 Cabal-Version:       >= 1.10
 Build-type:          Simple
 Synopsis:            Library for creating and modifying zip archives.


### PR DESCRIPTION
If bit 11 isn't set, the encoding is assumed to be IBM Code Page 437 (see http://www.pkware.com/documents/casestudies/APPNOTE.TXT), but the `fromString` function uses `encodeUtf8`. This becomes clear when you add an entry with special characters like 'ä' and then unpack the archive with something like `unzip`.

Technically, you'd also have to check this bit when reading an archive, but I don't know whether there even is a decoding function for IBM Code Page 437
