### PR TITLE
Support preservation of file modes on Posix

### DIFF
--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -64,3 +64,7 @@ Test-Suite test-zip-archive
   Default-Language:  Haskell98
   Ghc-Options:    -Wall
   Build-Tools:    zip
+  if os(windows)
+    cpp-options:     -D_WINDOWS
+  else
+    Build-depends:   unix


### PR DESCRIPTION
I notice that with the new support for Zip archives on in [Stack v1.0.4](https://github.com/commercialhaskell/stack/releases/tag/v1.0.4), Zip archives downloaded from Github are not extracted with the executable bit, and generally any file mode. It may case scripts invocations that rely on hash bangs (e.g. `"#!/bin/bash`) to fail executing.

So I tracked down the issue to the implementation of zip-archive, and incorporated the support for preservation of file modes. It's optional, and only for Posix, so it won't affect any existing users of zip-archive without their knowledge.