### PR TITLE
Bump bytestring version so toStrict is guaranteed

### DIFF
--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -30,7 +30,7 @@ Library
     Build-depends:   base >= 3 && < 5, pretty, containers
   else
     Build-depends:   base < 3
-  Build-depends:     binary >= 0.5, zlib, filepath, bytestring >= 0.9.0,
+  Build-depends:     binary >= 0.5, zlib, filepath, bytestring >= 0.10.0,
                      array, mtl, text >= 0.11, old-time, digest >= 0.0.0.1,
                      directory, time
   Exposed-modules:   Codec.Archive.Zip


### PR DESCRIPTION
I ran into this error while trying to install.

```
src/Codec/Archive/Zip.hs:633:48:
    Not in scope: `B.toStrict'
    Perhaps you meant `TL.toStrict' (imported from Data.Text.Lazy)
```

B (Data.ByteString.Lazy) does not have toStrict in any version of bytestring < 0.10.0.0. Bumping the dependency up to this 0.10.0.0 fixes the issue.