### PR TITLE
Lower directory requirements

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,6 @@ resolver: lts-10.3
 packages:
 - '.'
 extra-deps:
-- directory-1.3.1.5
 flags:
   zip-archive:
     splitbase: true

--- a/tests/test-zip-archive.hs
+++ b/tests/test-zip-archive.hs
@@ -38,7 +38,7 @@ createTestDirectoryWithSymlinks prefixDir  baseDir = do
   createDirectoryIfMissing True (testDir </> "1")
   writeFile (testDir </> "1/file.txt") "hello"
   cwd <- getCurrentDirectory
-  createFileLink (cwd </> testDir </> "1/file.txt") (testDir </> "link_to_file")
+  createSymbolicLink (cwd </> testDir </> "1/file.txt") (testDir </> "link_to_file")
   createSymbolicLink (cwd </> testDir </> "1") (testDir </> "link_to_directory")
   return testDir
 

--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -66,7 +66,7 @@ Test-Suite test-zip-archive
   Main-Is:        test-zip-archive.hs
   Hs-Source-Dirs: tests
   Build-Depends:  base >= 4.2 && < 5,
-                  directory >= 1.3.1, bytestring >= 0.9.0, process, time, old-time, 
+                  directory >= 1.3, bytestring >= 0.9.0, process, time, old-time, 
                   HUnit, zip-archive, temporary, filepath
   Default-Language:  Haskell98
   Ghc-Options:    -Wall


### PR DESCRIPTION
Use createSymbolicLink instead of createFileLink

Less is more.

Should fix #38 