### PR TITLE
Remove old-time, reduce dependencies.

### DIFF
--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -38,7 +38,7 @@ Library
     Build-depends:   base < 3
   Build-depends:     binary >= 0.6, zlib, filepath, bytestring >= 0.10.0,
                      array, mtl, text >= 0.11, old-time, digest >= 0.0.0.1,
-                     directory, time
+                     directory >= 1.2.0, time
   Exposed-modules:   Codec.Archive.Zip
   Default-Language:  Haskell98
   Hs-Source-Dirs:    src


### PR DESCRIPTION
This drops the usage of `old-time` which removes two dependencies (on `old-time` and `old-locale`). There are no changes external to the library, and all tests pass.