### PR TITLE
Remove Custom build-type

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,8 +1,0 @@
-import Distribution.Simple
-import Distribution.Simple.Program
-
-main :: IO ()
-main = defaultMainWithHooks simpleUserHooks
-  { hookedPrograms = [ simpleProgram "unzip"
-                     ]
-  }

--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -1,7 +1,7 @@
 Name:                zip-archive
 Version:             0.3.3
 Cabal-Version:       >= 1.10
-Build-type:          Custom
+Build-type:          Simple
 Synopsis:            Library for creating and modifying zip archives.
 Description:         The zip-archive library provides functions for creating, modifying,
                      and extracting files from zip archives.
@@ -50,9 +50,6 @@ Library
     cpp-options:     -D_WINDOWS
   else
     Build-depends:   unix
-
-custom-setup
-  setup-depends: base, Cabal
 
 Executable zip-archive
   if flag(executable)


### PR DESCRIPTION
This removes `bulid-type: Custom` from the `.cabal` file. This is necessary in order to get cross-compilation to work correctly. 

I don't think this has any adverse effect on the library itself, it merely means that the test suite will fail at runtime if `unzip` is not detected.