### PR TITLE
Fix a Cabal warning

### DIFF
--- a/zip-archive.cabal
+++ b/zip-archive.cabal
@@ -103,4 +103,4 @@ Test-Suite test-zip-archive
     cpp-options:     -D_WINDOWS
   else
     Build-depends:   unix
-  build-tools: unzip
+  build-tool-depends: unzip:unzip


### PR DESCRIPTION
```
Warning: zip-archive.cabal:106:3: The field "build-tools" is deprecated in the
Cabal specification version 2.0. Please use 'build-tool-depends' field
```